### PR TITLE
Added Location ID to our timeline output

### DIFF
--- a/src/domain/interfaces/itinerary/trip-timeline-event.interface.ts
+++ b/src/domain/interfaces/itinerary/trip-timeline-event.interface.ts
@@ -8,6 +8,7 @@ export interface TimelineEventModel {
 
 export interface StopEventData {
   stop_id: number;
+  location_id: number;
   name: string;
   latitude: number;
   longitude: number;
@@ -33,6 +34,7 @@ export interface LegEventData {
 
 export interface DepartureEventData {
   stop_id: number; // Always 0 or a special ID
+  location_id: number;
   name: string;
   latitude: number;
   longitude: number;

--- a/src/domain/itinerary/services/itinerary.service.ts
+++ b/src/domain/itinerary/services/itinerary.service.ts
@@ -184,6 +184,7 @@ export class ItineraryService {
       sequenceNumber: stop.sequence_number,
       data: {
         stop_id: stop.stop_id,
+        location_id: stop.location_id,
         name: stop.name,
         latitude: stop.location.latitude,
         longitude: stop.location.longitude,
@@ -226,6 +227,7 @@ export class ItineraryService {
       sequenceNumber: 0,
       data: {
         stop_id: 0,
+        location_id: stint.start_location_id,
         name: stint.start_location?.name ?? 'Start',
         latitude: stint.start_location?.latitude ?? 0,
         longitude: stint.start_location?.longitude ?? 0,


### PR DESCRIPTION
Timeline now includes location id's with stops, so we can use the starting location id, or location id's in general in place of stop id, though Stop id is still supported.